### PR TITLE
Give 404 if the Response is not mapped.

### DIFF
--- a/app/cmd/mockify.go
+++ b/app/cmd/mockify.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
@@ -75,6 +76,8 @@ func (route *Route) routeHandler(w http.ResponseWriter, r *http.Request) {
 	response, ok := responseMapping[key]
 	if !ok {
 		log.Errorf("Response not mapped for method %s and URI %s", r.Method, r.RequestURI)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(fmt.Sprintf("404 Response not mapped for method %s and URI %s", r.Method, r.RequestURI)))
 		return
 	}
 


### PR DESCRIPTION
Currently the page just goes blank if the Method or URI is not implemented.
This PR gives a 404 response and an error message.