### PR TITLE
WIP #13 initial docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1
+COPY app /app
+WORKDIR app
+RUN ls -alh
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main ./cmd/mockify.go
+WORKDIR cmd
+COPY main /main
+CMD ["main"]

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,4 +1,0 @@
-FROM scratch
-COPY app /app
-COPY main /app/cmd/
-CMD ["app/cmd/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  mockify:
+    build: .
+    volumes:
+      - ./app:/app
+    ports:
+      - "8001:8001"
+    command: ["app/cmd/main"]

--- a/docker_install.sh
+++ b/docker_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main ./app/cmd/mockify.go
 docker rmi -f mockify
-docker build -t mockify -f Dockerfile.scratch .
+docker build -t mockify -f Dockerfile .
 rm -f ./main


### PR DESCRIPTION
# WIP

The idea here is to add support for docker compose so anyone who wants to use mockify doesn't need to have go installed locally. I don't know which GO versions you require or anything yet, but this is the initial take on what I was thinking.

The commands in the `docker-compose.yml` file and the `Dockerfile` still need to be adjusted for pathing, etc.

https://docs.docker.com/compose/compose-file/

