### PR TITLE
Add response correlation

### DIFF
--- a/app/cmd/mockify.go
+++ b/app/cmd/mockify.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
@@ -34,6 +35,10 @@ type Response struct {
 	StatusCode int         `json:"statusCode"`
 	Body       interface{} `json:"body"`
 	Headers    map[string]string
+}
+
+type ResponseContent struct {
+	Message map[string]string
 }
 
 var responseMapping = make(map[string]Response)
@@ -102,7 +107,16 @@ func (route *Route) routeHandler(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Unable to marshall body: %s", response.Body)
 		os.Exit(5)
 	}
-	w.Write(body)
+
+	output := string(body)
+	for k, v := range mux.Vars(r) {
+		kr := fmt.Sprintf("{%s}", k)
+		output = strings.Replace(output, kr, v, -1)
+
+		log.Infof("Replace: %+v by %+v", kr, v)
+	}
+
+	w.Write([]byte(output))
 }
 
 func NewMockify() {


### PR DESCRIPTION
Hi

First thanks for this mock solution 👍 

I've need to add correlation between request and response.
So basically I replace mux vars by their value in the response.
Here's a simple example from your routes.json:
```
{
  "routes": [
    {
      "path": "/helloworld/{key}",
      "methods": [
        "GET",
        "POST"
      ],
      "responses": [
        {
          "methods": [
            "GET",
            "POST"
          ],
          "uri": "/helloworld/foo",
          "GET": {
            "statusCode": 200,
            "body": {
              "message": "[GET] Hello {key}!"
            },
            "headers": {
              "Content-Type": "application/json"
            }
          },
          "POST": {
            "statusCode": 200,
            "body": {
              "message": "[POST] Hello {key}!"
            },
            "headers": {
              "Content-Type": "application/json"
            }
          },
          "PUT": {},
          "DELETE": {}
        }
      ]
    }
  ]
}
```

And so on, `{key}` in the response content is replaced by the request url parameter:
```
curl -X GET \
  http://localhost:8001/helloworld/foo
```

```
{"message":"[GET] Hello foo!"}
```

What do you think about it ?